### PR TITLE
Add Standalone Server Config Option

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'cerulean'
 games { 'gta5' }
 
 client_scripts {
-    '@es_extended/locale.lua',
+    --'@es_extended/locale.lua',
     'shared/config.lua',
     'locales/en.lua',
     --'client/blacklist.lua',
@@ -49,7 +49,7 @@ files {
 }
 
 dependencies {
-    'es_extended'
+    -- 'es_extended'
 }
 
 exports {

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,144 +1,222 @@
-if not Config.EnableESXIdentityIntegration then
-    ESX = nil
-    TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
-
-    RegisterNetEvent('esx:onPlayerJoined')
-    AddEventHandler('esx:onPlayerJoined', function()
-        if not ESX.Players[source] then
-            local identifier
-
-            for k,v in ipairs(GetPlayerIdentifiers(source)) do
-                if string.match(v, 'license:') then
-                    identifier = string.sub(v, 9)
-                    break 
-                end
-            end
-
-            if identifier then
-                MySQL.Async.fetchScalar('SELECT 1 FROM users WHERE identifier = @identifier', {
-                    ['@identifier'] = identifier
-                }, function(result)
-                    if not result then
-                        -- first login stuff
-                    else
-                        -- subsequent login stuff
-                    end
-                end)
-            end
+local function getPlayerLicense(source)
+    for k,v in ipairs(GetPlayerIdentifiers(source)) do
+        if string.match(v, 'license:') then
+            return string.sub(v, 9)
         end
-    end)
+    end
+    return false
 end
 
-RegisterServerEvent('cui_character:save')
-AddEventHandler('cui_character:save', function(data)
-    local xPlayer = ESX.GetPlayerFromId(source)
+if not Config.StandAlone then  
+    if not Config.EnableESXIdentityIntegration then
+        ESX = nil
+        TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
 
-    MySQL.Async.execute('UPDATE users SET skin = @data WHERE identifier = @identifier', {
-        ['@data'] = json.encode(data),
-        ['@identifier'] = xPlayer.identifier
-    })
-end)
+        RegisterNetEvent('esx:onPlayerJoined')
+        AddEventHandler('esx:onPlayerJoined', function()
+            if not ESX.Players[source] then
+                local identifier = getPlayerLicense(source)
 
-RegisterServerEvent('esx_skin:save')
-AddEventHandler('esx_skin:save', function(data)
-    TriggerEvent('cui_character:save', data)
-end)
-
-ESX.RegisterServerCallback('esx_skin:getPlayerSkin', function(source, cb)
-    local xPlayer = ESX.GetPlayerFromId(source)
-
-    MySQL.Async.fetchAll('SELECT skin FROM users WHERE identifier = @identifier', {
-        ['@identifier'] = xPlayer.identifier
-    }, function(users)
-        local user = users[1]
-        local skin = nil
-
-        local jobSkin = {
-            skin_male   = xPlayer.job.skin_male,
-            skin_female = xPlayer.job.skin_female
-        }
-
-        if user.skin ~= nil then
-            skin = json.decode(user.skin)
-        end
-
-        cb(skin, jobSkin)
-    end)
-end)
-
-if Config.EnableESXIdentityIntegration then
-    ESX.RegisterServerCallback('cui_character:updateIdentity', function(source, cb, data)
-        local xPlayer = ESX.GetPlayerFromId(source)
-        
-        if xPlayer then
-            if checkNameFormat(data.firstname) and checkNameFormat(data.lastname) and checkSexFormat(data.sex) and checkDOBFormat(data.dateofbirth) and checkHeightFormat(data.height) then
-                local playerIdentity = {}
-                playerIdentity[xPlayer.identifier] = {
-                    firstName = formatName(data.firstname),
-                    lastName = formatName(data.lastname),
-                    dateOfBirth = data.dateofbirth,
-                    sex = data.sex,
-                    height = data.height
-                }
-
-                local currentIdentity = playerIdentity[xPlayer.identifier]
-
-                xPlayer.setName(('%s %s'):format(currentIdentity.firstName, currentIdentity.lastName))
-                xPlayer.set('firstName', currentIdentity.firstName)
-                xPlayer.set('lastName', currentIdentity.lastName)
-                xPlayer.set('dateofbirth', currentIdentity.dateOfBirth)
-                xPlayer.set('sex', currentIdentity.sex)
-                xPlayer.set('height', currentIdentity.height)
-
-                saveIdentityToDatabase(xPlayer.identifier, currentIdentity)
-                cb(true)
-            else
-                cb(false)
-            end
-        end
-    end)
-
-    ESX.RegisterServerCallback('cui_character:getIdentity', function(source, cb)
-        local xPlayer = ESX.GetPlayerFromId(source)
-
-        MySQL.Async.fetchAll('SELECT firstname, lastname, dateofbirth, sex, height FROM users WHERE identifier = @identifier', {
-            ['@identifier'] = xPlayer.identifier
-        }, function(users)
-            local user = users[1]
-            local identity = {}
-
-            if user ~= nil then
-                for k, v in pairs(user) do
-                    identity[k] = v
+                if identifier then
+                    MySQL.ready(function()
+                        MySQL.Async.fetchScalar('SELECT 1 FROM users WHERE identifier = @identifier', {
+                            ['@identifier'] = identifier
+                        }, function(result)
+                            if not result then
+                                -- first login stuff
+                            else
+                                -- subsequent login stuff
+                            end
+                        end)
+                    end)
                 end
             end
+        end)
+    end
 
-            cb(identity)
+    RegisterServerEvent('cui_character:save')
+    AddEventHandler('cui_character:save', function(data)
+        local xPlayer = ESX.GetPlayerFromId(source)
+        MySQL.ready(function()
+            MySQL.Async.execute('UPDATE users SET skin = @data WHERE identifier = @identifier', {
+                ['@data'] = json.encode(data),
+                ['@identifier'] = xPlayer.identifier
+            })
         end)
     end)
+
+    RegisterServerEvent('esx_skin:save')
+    AddEventHandler('esx_skin:save', function(data)
+        TriggerEvent('cui_character:save', data)
+    end)
+
+    ESX.RegisterServerCallback('esx_skin:getPlayerSkin', function(source, cb)
+        local xPlayer = ESX.GetPlayerFromId(source)
+        MySQL.ready(function()
+            MySQL.Async.fetchAll('SELECT skin FROM users WHERE identifier = @identifier', {
+                ['@identifier'] = xPlayer.identifier
+            }, function(users)
+                local user = users[1]
+                local skin = nil
+
+                local jobSkin = {
+                    skin_male   = xPlayer.job.skin_male,
+                    skin_female = xPlayer.job.skin_female
+                }
+
+                if user.skin ~= nil then
+                    skin = json.decode(user.skin)
+                end
+
+                cb(skin, jobSkin)
+            end)
+        end)
+    end)
+
+    if Config.EnableESXIdentityIntegration then
+        ESX.RegisterServerCallback('cui_character:updateIdentity', function(source, cb, data)
+            local xPlayer = ESX.GetPlayerFromId(source)
+            
+            if xPlayer then
+                if checkNameFormat(data.firstname) and checkNameFormat(data.lastname) and checkSexFormat(data.sex) and checkDOBFormat(data.dateofbirth) and checkHeightFormat(data.height) then
+                    local playerIdentity = {}
+                    playerIdentity[xPlayer.identifier] = {
+                        firstName = formatName(data.firstname),
+                        lastName = formatName(data.lastname),
+                        dateOfBirth = data.dateofbirth,
+                        sex = data.sex,
+                        height = data.height
+                    }
+
+                    local currentIdentity = playerIdentity[xPlayer.identifier]
+
+                    xPlayer.setName(('%s %s'):format(currentIdentity.firstName, currentIdentity.lastName))
+                    xPlayer.set('firstName', currentIdentity.firstName)
+                    xPlayer.set('lastName', currentIdentity.lastName)
+                    xPlayer.set('dateofbirth', currentIdentity.dateOfBirth)
+                    xPlayer.set('sex', currentIdentity.sex)
+                    xPlayer.set('height', currentIdentity.height)
+
+                    saveIdentityToDatabase(xPlayer.identifier, currentIdentity)
+                    cb(true)
+                else
+                    cb(false)
+                end
+            end
+        end)
+
+        ESX.RegisterServerCallback('cui_character:getIdentity', function(source, cb)
+            local xPlayer = ESX.GetPlayerFromId(source)
+            MySQL.ready(function()
+                MySQL.Async.fetchAll('SELECT firstname, lastname, dateofbirth, sex, height FROM users WHERE identifier = @identifier', {
+                    ['@identifier'] = xPlayer.identifier
+                }, function(users)
+                    local user = users[1]
+                    local identity = {}
+
+                    if user ~= nil then
+                        for k, v in pairs(user) do
+                            identity[k] = v
+                        end
+                    end
+
+                    cb(identity)
+                end)
+            end)
+        end)
+    end
+
+    ESX.RegisterCommand('character', 'admin', function(xPlayer, args, showError)
+        xPlayer.triggerEvent('cui_character:open', { 'identity', 'features', 'style', 'apparel' })
+        end, true, {help = 'Open full character editor.', validate = true, arguments = {}
+    })
+
+    ESX.RegisterCommand('identity', 'admin', function(xPlayer, args, showError)
+        xPlayer.triggerEvent('cui_character:open', { 'identity' })
+        end, true, {help = 'Open character identity editor.', validate = true, arguments = {}
+    })
+
+    ESX.RegisterCommand('features', 'admin', function(xPlayer, args, showError)
+        xPlayer.triggerEvent('cui_character:open', { 'features' })
+        end, true, {help = 'Open character physical features editor.', validate = true, arguments = {}
+    })
+
+    ESX.RegisterCommand('style', 'admin', function(xPlayer, args, showError)
+        xPlayer.triggerEvent('cui_character:open', { 'style' })
+        end, true, {help = 'Open character style editor.', validate = true, arguments = {}
+    })
+
+    ESX.RegisterCommand('apparel', 'admin', function(xPlayer, args, showError)
+        xPlayer.triggerEvent('cui_character:open', { 'apparel' })
+        end, true, {help = 'Open character apparel editor.', validate = true, arguments = {}
+    })
+
+-- Standalone Deployment
+else
+    -- Create the database table if it does not exist
+    MySQL.ready(function()
+        MySQL.Async.execute('CREATE TABLE IF NOT EXISTS `player_skins` (`id` int(11) NOT NULL auto_increment, `identifier` varchar(128) NOT NULL, `skin` LONGTEXT NULL DEFAULT NULL, PRIMARY KEY  (`id`), UNIQUE(`identifier`))',{}, 
+        function() end)
+    end)
+
+    RegisterServerEvent('cui_character:save')
+    AddEventHandler('cui_character:save', function(data)
+        local _source = source
+        local license = getPlayerLicense(_source)
+
+        if license then
+            MySQL.ready(function()
+                MySQL.Async.execute('INSERT INTO `player_skins` (`identifier`, `skin`) VALUES (@identifier, @skin) ON DUPLICATE KEY UPDATE `skin` = @skin', {
+                    ['@skin'] = json.encode(data),
+                    ['@identifier'] = license
+                })
+            end)
+        end
+    end)
+
+    RegisterServerEvent('cui_character:requestPlayerData')
+    AddEventHandler('cui_character:requestPlayerData', function()
+        local _source = source
+        local license = getPlayerLicense(_source)
+
+        if license then
+            MySQL.ready(function()
+                MySQL.Async.fetchAll('SELECT skin FROM player_skins WHERE identifier = @identifier', {
+                    ['@identifier'] = license
+                }, function(users)
+                    local playerData = { skin = nil, newPlayer = true}
+                    if users and users[1] ~= nil and users[1].skin ~= nil then
+                        playerData.skin = json.decode(users[1].skin)
+                        playerData.newPlayer = false
+                    end
+                    TriggerClientEvent('cui_character:recievePlayerData', _source, playerData)
+                end)
+            end)
+        end
+    end)
+
+    RegisterCommand("character", function(source, args, rawCommand)
+        if (source > 0) then
+            TriggerClientEvent('cui_character:open', source, { 'features', 'style', 'apparel' })
+        end
+    end, true)
+
+    RegisterCommand("features", function(source, args, rawCommand)
+        if (source > 0) then
+            TriggerClientEvent('cui_character:open', source, { 'features' })
+        end
+    end, true)
+
+    RegisterCommand("style", function(source, args, rawCommand)
+        if (source > 0) then
+            TriggerClientEvent('cui_character:open', source, { 'style' })
+        end
+    end, true)
+
+    RegisterCommand("apparel", function(source, args, rawCommand)
+        if (source > 0) then
+            TriggerClientEvent('cui_character:open', source, { 'apparel' })
+        end
+    end, true)
+
 end
-
-ESX.RegisterCommand('character', 'admin', function(xPlayer, args, showError)
-	xPlayer.triggerEvent('cui_character:open', { 'identity', 'features', 'style', 'apparel' })
-    end, true, {help = 'Open full character editor.', validate = true, arguments = {}
-})
-
-ESX.RegisterCommand('identity', 'admin', function(xPlayer, args, showError)
-	xPlayer.triggerEvent('cui_character:open', { 'identity' })
-    end, true, {help = 'Open character identity editor.', validate = true, arguments = {}
-})
-
-ESX.RegisterCommand('features', 'admin', function(xPlayer, args, showError)
-	xPlayer.triggerEvent('cui_character:open', { 'features' })
-    end, true, {help = 'Open character physical features editor.', validate = true, arguments = {}
-})
-
-ESX.RegisterCommand('style', 'admin', function(xPlayer, args, showError)
-	xPlayer.triggerEvent('cui_character:open', { 'style' })
-    end, true, {help = 'Open character style editor.', validate = true, arguments = {}
-})
-
-ESX.RegisterCommand('apparel', 'admin', function(xPlayer, args, showError)
-	xPlayer.triggerEvent('cui_character:open', { 'apparel' })
-    end, true, {help = 'Open character apparel editor.', validate = true, arguments = {}
-})

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -133,4 +133,27 @@ end
     If you don't do it, you will experience a really weird glitch on character spawn after loading screen.
 --]]
 Config.ExtendedMode = false
-Config.UseSteamID = false
+
+--[[
+    This is servers withoout the ESX framework. 
+
+    If you wish to use this for a stand alone server, enable this and MAKE SURE YOU MODIFY fxmanifest.lua:
+
+    Delete this part (around line 5):
+    '@es_extended/locale.lua'
+
+    And delete this part (around line 51):
+
+        dependencies {
+            'es_extended'
+        }
+
+    If you don't do it, you will receive an error when launching your server.
+--]]
+Config.StandAlone = false
+
+if Config.StandAlone then
+    Config.ExtendedMode = false
+    Config.EnableESXIdentityIntegration = false
+    Config.EnableNewIdentityProviders = false
+end


### PR DESCRIPTION
This PR will create an option in the config file for standalone servers. This will deactivate all ESX and essentialmode dependencies and rely only on mysql-async. The database table will automatically be created if it does not exist. If standalone mode is enabled, the resource manifest must be modified by the user as well to remove ESX dependencies from the resource. I've included details on what changes to make within the config file, following your format.

In addition, I've wrapped all SQL queries in the MySQL.Ready function to ensure the resource will wait on the DB in the unlikely chance it needs to.

These additions should retain full functionality for ESX, but I am unable to test it at this time due to not having an ESX server setup. Let me know if there are any modifications you'd like me to make, or feel free to make the tweaks prior to merging.